### PR TITLE
The staticfiles app requires STATIC_URL to be defined in settings.py

### DIFF
--- a/show_route/settings.py
+++ b/show_route/settings.py
@@ -119,6 +119,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/3.2/howto/static-files/
 
+STATIC_URL = 'static/'
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/3.2/ref/settings/#default-auto-field


### PR DESCRIPTION
Running the development server throws a ImproperlyConfigured exception as STATIC_URL is not defined in the settings.py file.
`django.core.exceptions.ImproperlyConfigured: You're using the staticfiles app without having set the required STATIC_URL setting.`